### PR TITLE
fix(android): Fix breadcrumb data for non-string types

### DIFF
--- a/src/nssentry.android.ts
+++ b/src/nssentry.android.ts
@@ -179,13 +179,21 @@ export namespace NSSentry {
                     try {
                         if (breadcrumb.data) {
                             Object.keys(breadcrumb.data).forEach((k) => {
-                                const value = breadcrumb.data[k];
+                                let value = breadcrumb.data[k];
                                 // in case a `status_code` entry got accidentally stringified as a float
-                                if (k === 'status_code') {
-                                    nBreadcumb.setData(k, value && value.endsWith('.0') ? value.replace('.0', '') : value);
-                                } else {
-                                    nBreadcumb.setData(k, value);
+                                if (k === 'status_code' && typeof value === 'string' && value.endsWith('.0')) {
+                                    value = value.replace('.0', '');
+                                } else if (typeof value === 'boolean') {
+                                    value = new java.lang.Boolean(value);
+                                } else if (typeof value === 'number') {
+                                    value = value.toString();
+                                } else if (Array.isArray(value)) {
+                                    value = new org.json.JSONArray(JSON.stringify(value));
+                                } else if (value && typeof value === 'object') {
+                                    value = new org.json.JSONObject(JSON.stringify(value));
                                 }
+
+                                nBreadcumb.setData(k, value);
                             });
                         }
                     } catch (e) {


### PR DESCRIPTION
Hi @farfromrefug, 

I made a small fix for a recurring bug that I had on a project.

The warning was `Discarded breadcrumb.data since it was not an object`. It turned out that an exception was raised for every non-string type: 

```
Error: Cannot convert number to Ljava/lang/Object; at index 1
Error: Cannot convert array to Ljava/lang/Object; at index 1
Error: Cannot convert object to Ljava/lang/Object; at index 1
```

The fix mostly consist of a manual cast to JSON types or string. I'm not sure this is the most performant way of doing it (especially when I use `JSONArray` and `JSONObject`.

What do you think? If it seems ok, I'll merge it in master.