### PR TITLE
Native breadcrumbs hook

### DIFF
--- a/src/wrapper.android.ts
+++ b/src/wrapper.android.ts
@@ -690,6 +690,18 @@ export namespace NATIVE {
                                     },
                                 })
                             );
+                            config.setBeforeBreadcrumb(
+                                new io.sentry.SentryOptions.BeforeBreadcrumbCallback({
+                                    execute(event, hint) {
+                                        if (options.beforeBreadcrumb) {
+                                            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+                                            return options.beforeBreadcrumb(event, hint);
+                                        } else {
+                                            return event;
+                                        }
+                                    }
+                                })
+                            );
                             nSentryOptions = config;
                             sentryOptions = options;
                         } catch(err) {


### PR DESCRIPTION
Hello @farfromrefug,

it appeared there is no way to filter breadcrumbs coming from the underlying native SDKs, so I've implemented `beforeBreadcrumb` for both platforms in a way similar to `beforeSend`.