### PR TITLE
feat: update sentry/webpack-plugin to v2.2.2

### DIFF
--- a/demo-vue/package.json
+++ b/demo-vue/package.json
@@ -15,7 +15,7 @@
         "@nativescript/ios": "8.4.0",
         "@nativescript/webpack": "~5.0.12",
         "@sentry/cli": "2.10.0",
-        "@sentry/webpack-plugin": "1.20.0",
+        "@sentry/webpack-plugin": "2.2.2",
         "babel-loader": "~9.1.0",
         "cross-var": "^1.1.0",
         "nativescript-vue-template-compiler": "~2.9.3",

--- a/demo-vue/webpack.config.js
+++ b/demo-vue/webpack.config.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const nsWebpack = require('@nativescript/webpack');
 const { dirname, join, relative, resolve, sep } = require('path');
 const { readdirSync, readFileSync } = require('fs');
-const SentryCliPlugin = require('@sentry/webpack-plugin');
+const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 module.exports = (env, params = {}) => {
     nsWebpack.init(env);
     nsWebpack.chainWebpack(config=>{
@@ -51,14 +51,18 @@ module.exports = (env, params = {}) => {
         })
     );
     // config.plugins.push(
-    //     new SentryCliPlugin({
+    //     sentryWebpackPlugin({
     //         release: appVersion,
     //         urlPrefix: SENTRY_PREFIX,
     //         rewrite: true,
-    //         release: `${nconfig.id}@${appVersion}+${buildNumber}`,
-    //         dist: `${buildNumber}.${platform}`,
-    //         ignoreFile: '.sentrycliignore',
-    //         include: [dist, join(dist, SOURCEMAP_REL_DIR)]
+    //         release: {
+    //             name: `${nconfig.id}@${appVersion}+${buildNumber}`,
+    //             dist: `${buildNumber}.${platform}`,
+    //             uploadLegacySourcemaps: {
+    //                 ignoreFile: '.sentrycliignore',
+    //                 paths: [dist, join(dist, SOURCEMAP_REL_DIR)]
+    //             },
+    //         },
     //     })
     // );
     return config;


### PR DESCRIPTION
Hey Martin, I was using this plugin and ran into an issue with the latest `@sentry/webpack-plugin`. It has a slightly different syntax for uploading the sourcemaps. Thought I'd open a PR to update your demo app to use the latest version of the plugin along with the updated sourcemap upload function. I left it commented out as you had it previously, but it might be a good reference for anyone who ran into the same issue I did :) 