### PR TITLE
fix(ios): bump native Sentry to 8.48.0 to resolve iOS 18.4 build issue

### DIFF
--- a/packages/sentry/platforms/ios/Podfile
+++ b/packages/sentry/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Sentry/HybridSDK', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.36.0'
+pod 'Sentry/HybridSDK', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.48.0'


### PR DESCRIPTION
On iOS 8.36.0 has a build issue on the just released iOS 18.4 / Xcode 16.3.
Bumping the Pod to 8.48.0 resolves this, but fair warning: I have tested some but not all of the plugin's features.