### PR TITLE
fix nullability warning noise with upgrade

### DIFF
--- a/packages/sentry/platforms/ios/Podfile
+++ b/packages/sentry/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Sentry/HybridSDK', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.48.0'
+pod 'Sentry/HybridSDK', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '8.52.1'


### PR DESCRIPTION
There's some persistent nullability warning noise in our NS build that would be nice to eliminate. Bumping to latest upstream fixes it.