### PR TITLE
fix: Add .mjs as a valid javascript file extension

### DIFF
--- a/src/sentry/integrations/debugsymbolicator.ts
+++ b/src/sentry/integrations/debugsymbolicator.ts
@@ -43,7 +43,7 @@ export interface NativescriptStackFrame extends StackFrame {
 
 function createFrame(frame: Partial<NativescriptStackFrame>) {
     frame.in_app = (frame.filename && !frame.filename.includes('node_modules')) || (!!frame.colno && !!frame.lineno);
-    frame.platform = frame.filename.endsWith('.js') ? 'javascript' : 'android';
+    frame.platform = frame.filename ? (/\.(mjs|js)$/.test(frame.filename) ? 'javascript' : 'android') : undefined;
 
     return frame;
 }

--- a/src/sentry/integrations/default.ts
+++ b/src/sentry/integrations/default.ts
@@ -57,8 +57,7 @@ export function getDefaultIntegrations(options: NativescriptClientOptions & Nati
         return frame;
     };
 
-    rewriteFrameIntegration = new RewriteFrames({}) as any;
-    rewriteFrameIntegration._iteratee = iteratee;
+    rewriteFrameIntegration = new RewriteFrames({ iteratee }) as any;
 
     // if (notWeb()) {
     integrations.push(new NativescriptErrorHandlers(options));


### PR DESCRIPTION
Two small fixes so Sentry's dashboard renders code snippets for stack frames originating in NativeScript .mjs files.

##### Changes
`src/sentry/integrations/debugsymbolicator.ts` — `createFrame`: match .mjs in addition to .js when tagging a frame as platform: 'javascript'. Without this, .mjs frames were tagged 'android' and routed through the JVM symbolication path on the server.

`src/sentry/integrations/default.ts` — `RewriteFrames` wiring: pass the iteratee via the constructor so it actually runs in the event pipeline. Otherwise the source snippets are shown only for `captureMessage`, but not for `captureException` and the native code errors.

|Before|After|
|-|-|
|<img width="1291" height="844" alt="Screenshot 2026-05-20 at 11 37 25" src="https://github.com/user-attachments/assets/8e8d6483-e294-46ae-9b3d-d6889dcdb0eb" />|<img width="1291" height="752" alt="Screenshot 2026-05-20 at 11 37 46" src="https://github.com/user-attachments/assets/84830d63-9791-486d-a5d6-1cf76b00ae9b" />|
