### PR TITLE
fix: expose iteratee and update deprecated integrations

### DIFF
--- a/src/sentry/client.ts
+++ b/src/sentry/client.ts
@@ -16,7 +16,7 @@ import { mergeOutcomes } from './utils/outcome';
 import { NATIVE } from './wrapper';
 import { Screenshot } from './integrations/screenshot';
 import { NativescriptTracing } from './tracing';
-import { rewriteFrameIntegration } from './integrations/default';
+import { frameIteratee } from './integrations/default';
 import { parseErrorStack } from './integrations/debugsymbolicator';
 
 function wrapNativeException(ex, errorType = typeof ex) {
@@ -97,7 +97,7 @@ export class NativescriptClient extends BaseClient<NativescriptClientOptions> {
         if (exception['nativeException']) {
             try {
                 const stack = parseErrorStack({ stack: 'at ' + exception['stackTrace'] } as any).filter((f) => f.platform !== 'javascript');
-                stack.forEach((frame) => rewriteFrameIntegration._iteratee(frame));
+                stack.forEach((frame) => frameIteratee(frame));
                 event.exception.values.unshift({
                     type: 'NativeException',
                     value: exception.toString(),
@@ -111,8 +111,8 @@ export class NativescriptClient extends BaseClient<NativescriptClientOptions> {
         } else if (__IOS__ && exception['stackTrace']) {
             // try {
             // const stack = parseErrorStack({ stack: 'at ' + exception['stackTrace'] } as any).filter((f) => f.platform !== 'javascript');
-            // stack.forEach((frame) => rewriteFrameIntegration._iteratee(frame));
-            // event.exception.values[0].stacktrace.frames.forEach((frame) => rewriteFrameIntegration._iteratee(frame));
+            // stack.forEach((frame) => frameIteratee(frame));
+            // event.exception.values[0].stacktrace.frames.forEach((frame) => frameIteratee(frame));
             // event.exception.values[0].stacktrace.frames = event.exception.values[0].stacktrace.frames.reverse();
             // event.exception.values.unshift({
             //     type: 'NativeException',
@@ -140,7 +140,7 @@ export class NativescriptClient extends BaseClient<NativescriptClientOptions> {
             }
             const values = event.exception.values.map((exception: Exception): Thread => {
                 if (exception.stacktrace) {
-                    exception.stacktrace.frames.forEach((frame) => rewriteFrameIntegration._iteratee(frame));
+                    exception.stacktrace.frames.forEach((frame) => frameIteratee(frame));
                 }
                 return {
                     stacktrace: exception.stacktrace

--- a/src/sentry/integrations/default.ts
+++ b/src/sentry/integrations/default.ts
@@ -1,4 +1,4 @@
-import { HttpClient, RewriteFrames } from '@sentry/integrations';
+import { httpClientIntegration, rewriteFramesIntegration } from '@sentry/integrations';
 // import { Integrations as BrowserReactIntegrations } from '@sentry/react';
 import type { Integration, StackFrame } from '@sentry/types';
 
@@ -20,9 +20,12 @@ import { SdkInfo } from './sdkinfo';
 // import { Spotlight } from './spotlight';
 // import { ViewHierarchy } from './viewhierarchy';
 
-export let rewriteFrameIntegration: {
-    _iteratee: (frame: StackFrame) => StackFrame;
-};
+/**
+ * The frame iteratee function used to rewrite stack frames.
+ * Exported separately so it can be referenced without going through the integration object.
+ */
+export let frameIteratee: (frame: StackFrame) => StackFrame;
+
 /**
  * Returns the default ReactNative integrations based on the current environment.
  *
@@ -57,7 +60,7 @@ export function getDefaultIntegrations(options: NativescriptClientOptions & Nati
         return frame;
     };
 
-    rewriteFrameIntegration = new RewriteFrames({ iteratee }) as any;
+    frameIteratee = iteratee;
 
     // if (notWeb()) {
     integrations.push(new NativescriptErrorHandlers(options));
@@ -85,7 +88,7 @@ export function getDefaultIntegrations(options: NativescriptClientOptions & Nati
     //     integrations.push(new DebugSymbolicator());
     // }
 
-    integrations.push(rewriteFrameIntegration as any);
+    integrations.push(rewriteFramesIntegration({ iteratee }) as Integration);
 
     if (options.enableNative) {
         integrations.push(new DeviceContext());
@@ -109,7 +112,7 @@ export function getDefaultIntegrations(options: NativescriptClientOptions & Nati
         integrations.push(new NativescriptTracing());
     }
     if (options.enableCaptureFailedRequests) {
-        integrations.push(new HttpClient());
+        integrations.push(httpClientIntegration() as Integration);
     }
 
     // if (isExpoGo()) {

--- a/src/sentry/wrapper.android.ts
+++ b/src/sentry/wrapper.android.ts
@@ -9,7 +9,7 @@ import { NativescriptOptions } from './options';
 import { utf8ToBytes } from './vendor';
 import { SDK_NAME } from './version';
 import { CLog, CLogTypes } from '.';
-import { rewriteFrameIntegration } from './integrations/default';
+import { frameIteratee } from './integrations/default';
 import { splitObject } from './utils/object';
 
 enum JavaType {
@@ -578,7 +578,7 @@ export namespace NATIVE {
                                                             const jsStackTrace: string = throwable.getIncomingStackTrace?.();
                                                             if (jsStackTrace) {
                                                                 const stack = parseErrorStack({ stack: 'at ' + jsStackTrace } as any).reverse();
-                                                                stack.forEach((frame) => rewriteFrameIntegration._iteratee(frame));
+                                                                stack.forEach((frame) => frameIteratee(frame));
                                                                 addJavascriptExceptionInterface(event, 'Error', throwable.getMessage(), stack.reverse());
                                                             }
                                                         }

--- a/src/sentry/wrapper.ios.ts
+++ b/src/sentry/wrapper.ios.ts
@@ -4,7 +4,7 @@ import { parseErrorStack } from './integrations/debugsymbolicator';
 import { isHardCrash } from './misc';
 import { NativescriptOptions } from './options';
 import { utf8ToBytes } from './vendor';
-import { rewriteFrameIntegration } from './integrations/default';
+import { frameIteratee } from './integrations/default';
 import { splitObject } from './utils/object';
 
 const numberHasDecimals = function (value: number): boolean {
@@ -368,7 +368,7 @@ export namespace NATIVE {
                                 const errorMessage = matches[1];
                                 const jsStackTrace = exceptionvalue.substring(exceptionvalue.indexOf(matches[2]));
                                 const stack = parseErrorStack({ stack: 'at ' + jsStackTrace } as any).reverse();
-                                stack.forEach((frame) => rewriteFrameIntegration._iteratee(frame));
+                                stack.forEach((frame) => frameIteratee(frame));
                                 addJavascriptExceptionInterface(event, 'Error', errorMessage, stack.reverse());
                                 exception.type = 'NativeScriptException';
                                 exception.value = errorMessage;


### PR DESCRIPTION
#### Issue
There was some logic in `client.ts`, `wrapper.android.ts`, and `wrapper.ios.ts` that used to access iteratee via the integration object. So removing the `_iteratee` assignment in #33 broke this link while passing iteratee to the `RewriteFrames` constructor fixed the missing source snippet issue for the native errors and `captureException` calls.

#### Fix
Exported frame iteratee as `frameIteratee`. Replaced `rewriteFrameIntegration._iteratee` with direct `frameIteratee(...)` so the stacks can be rewritten without reaching into integration internals.

Adopted the newer `@sentry/integrations` factory exports (`rewriteFramesIntegration`, `httpClientIntegration`) as the `RewriteFrames`, and `HttpClient` are deprecated.

